### PR TITLE
Feature/update gs clock determination

### DIFF
--- a/conf/gnss-sdr_GPS_L1_bladeRF2_micro_hybrid_nav.conf
+++ b/conf/gnss-sdr_GPS_L1_bladeRF2_micro_hybrid_nav.conf
@@ -123,8 +123,10 @@ Observables.dump_filename=./observables.dat
 
 ;######### PVT CONFIG ############
 PVT.implementation=RTKLIB_PVT
-PVT.positioning_mode=Single
 ;PVT.positioning_mode=PPP_Static
+;PVT.positioning_mode=Single
+PVT.positioning_mode=PPP_Fixed
+# NOTE: PVT.positioning_mode=Fixed is different from Single and fixed_position=true. (estimates only clock_bias and drift by pseudorange measurements)
 PVT.fixed_position=true
 # TODO: need to set belows to the same values as -l option of bladeGPS
 PVT.known_pos_lat=0.0  # latitude [deg]

--- a/conf/gnss-sdr_GPS_L1_bladeRF2_micro_hybrid_nav.conf
+++ b/conf/gnss-sdr_GPS_L1_bladeRF2_micro_hybrid_nav.conf
@@ -6,7 +6,7 @@
 [GNSS-SDR]
 
 ;######### GLOBAL OPTIONS ##################
-GNSS-SDR.internal_fs_sps=3000000
+GNSS-SDR.internal_fs_sps=5000000
 ;GNSS-SDR.telecommand_enabled=true
 ;GNSS-SDR.telecommand_tcp_port=3333
 GNSS-SDR.num_sources=1
@@ -19,7 +19,7 @@ ReceiverAntennaAttitude.el_deg=90.0
 ;######### SIGNAL_SOURCE CONFIG ############
 SignalSource.implementation=Osmosdr_Signal_Source
 SignalSource.item_type=gr_complex
-SignalSource.sampling_frequency=3000000
+SignalSource.sampling_frequency=5000000
 SignalSource.freq=1575420000
 ;# RF Gain: LNA Gain {0, 3, 6}
 SignalSource.gain=60
@@ -29,7 +29,7 @@ SignalSource.repeat=false
 SignalSource.osmosdr_args=bladerf=8b2291,biastee=0,nchan=2,agc_mode='manual',clock_ref=1 ;,verbosity=info  ; This line enables the bladeRF
 SignalSource.dump=false
 SignalSource.dump_filename=./signal_source.dat
-SignalSource.if_bw=3000000
+SignalSource.if_bw=2046000
 ; # RF_channels should be 2 in hybrid mode
 SignalSource.RF_channels=2
 
@@ -45,7 +45,7 @@ InputFilter.implementation=Freq_Xlating_Fir_Filter
 InputFilter.decimation_factor=1
 InputFilter.input_item_type=gr_complex
 InputFilter.output_item_type=gr_complex
-InputFilter.sampling_frequency=3000000
+InputFilter.sampling_frequency=5000000
 InputFilter.taps_item_type=float
 InputFilter.number_of_taps=5
 InputFilter.number_of_bands=2
@@ -94,7 +94,7 @@ Tracking_1C.item_type=gr_complex
 Tracking_1C.extend_correlation_symbols=1
 Tracking_1C.early_late_space_chips=0.5
 Tracking_1C.early_late_space_narrow_chips=0.25
-Tracking_1C.pll_bw_hz=35
+Tracking_1C.pll_bw_hz=20
 Tracking_1C.dll_bw_hz=2.0
 Tracking_1C.pll_bw_narrow_hz=5.0
 Tracking_1C.dll_bw_narrow_hz=1.50
@@ -123,9 +123,14 @@ Observables.dump_filename=./observables.dat
 
 ;######### PVT CONFIG ############
 PVT.implementation=RTKLIB_PVT
-;PVT.positioning_mode=Single
-PVT.positioning_mode=PPP_Static
-PVT.output_rate_ms=100
+PVT.positioning_mode=Single
+;PVT.positioning_mode=PPP_Static
+PVT.fixed_position=true
+# TODO: need to set belows to the same values as -l option of bladeGPS
+PVT.known_pos_lat=0.0  # latitude [deg]
+PVT.known_pos_lon=135.0  # longitude [deg]
+PVT.known_pos_alt=0.0  # altitude [m]
+PVT.output_rate_ms=1000
 PVT.display_rate_ms=3000
 ;PVT.iono_model=Broadcast
 ;PVT.trop_model=Saastamoinen
@@ -170,7 +175,7 @@ InputFilter1.implementation=Freq_Xlating_Fir_Filter
 InputFilter1.decimation_factor=1
 InputFilter1.input_item_type=gr_complex
 InputFilter1.output_item_type=gr_complex
-InputFilter1.sampling_frequency=3000000
+InputFilter1.sampling_frequency=5000000
 InputFilter1.taps_item_type=float
 InputFilter1.number_of_taps=5
 InputFilter1.number_of_bands=2

--- a/src/algorithms/PVT/adapters/rtklib_pvt.cc
+++ b/src/algorithms/PVT/adapters/rtklib_pvt.cc
@@ -794,6 +794,11 @@ Rtklib_Pvt::Rtklib_Pvt(const ConfigurationInterface* configuration,
     const double carrier_phase_error_factor_b = configuration->property(role + ".carrier_phase_error_factor_b", 0.003);
 
     const bool bancroft_init = configuration->property(role + ".bancroft_init", true);
+    const bool clock_bias_fixed = configuration->property(role + ".enable_rx_clock_propagation", false);
+    const bool fixed_position_mode = configuration->property(role + ".fixed_position", false);
+    const double known_pos_lat = configuration->property(role + ".known_pos_lat", 0.0);
+    const double known_pos_lon = configuration->property(role + ".known_pos_lon", 135.0);
+    const double known_pos_alt = configuration->property(role + ".known_pos_alt", 0.0);
 
     snrmask_t snrmask = {{}, {{}, {}}};
 
@@ -854,8 +859,10 @@ Rtklib_Pvt::Rtklib_Pvt(const ConfigurationInterface* configuration,
         {{}, {{}, {}}, {{}, {}}, {}, {}},                                                  /* exterr_t exterr   extended receiver error model */
         0,                                                                                 /* disable L2-AR */
         {},                                                                                /* char pppopt[256]   ppp option   "-GAP_RESION="  default gap to reset iono parameters (ep) */
-        bancroft_init,                                                                      /* enable Bancroft initialization for the first iteration of the PVT computation, useful in some geometries */
-        false                                                                               /* enable clock bias fixed mode, when enable_rx_clock_propagation is enable, it will be enable after fixing position and clock bias */
+        bancroft_init,                                                                     /* enable Bancroft initialization for the first iteration of the PVT computation, useful in some geometries */
+        clock_bias_fixed,                                                                  /* enable clock bias fixed mode, when enable_rx_clock_propagation is enable, it will be enable after fixing position and clock bias */
+        fixed_position_mode,                                                               /* enable fixed position mode so estimate only the receiver clock bias */
+        {known_pos_lat, known_pos_lon, known_pos_alt}                                      /* known position for the fixed_position_mode */
     };
 
     rtkinit(&rtk, &rtklib_configuration_options);

--- a/src/algorithms/PVT/adapters/rtklib_pvt.cc
+++ b/src/algorithms/PVT/adapters/rtklib_pvt.cc
@@ -501,6 +501,10 @@ Rtklib_Pvt::Rtklib_Pvt(const ConfigurationInterface* configuration,
         {
             positioning_mode = PMODE_KINEMA;
         }
+    if (positioning_mode_str == "Fixed")
+        {
+            positioning_mode = PMODE_FIXED;
+        }
     if (positioning_mode_str == "PPP_Static")
         {
             positioning_mode = PMODE_PPP_STATIC;
@@ -508,6 +512,10 @@ Rtklib_Pvt::Rtklib_Pvt(const ConfigurationInterface* configuration,
     if (positioning_mode_str == "PPP_Kinematic")
         {
             positioning_mode = PMODE_PPP_KINEMA;
+        }
+    if (positioning_mode_str == "PPP_Fixed")
+        {
+            positioning_mode = PMODE_PPP_FIXED;
         }
     if (positioning_mode_str == "EKF_Satellite")
         {
@@ -802,6 +810,9 @@ Rtklib_Pvt::Rtklib_Pvt(const ConfigurationInterface* configuration,
 
     snrmask_t snrmask = {{}, {{}, {}}};
 
+    double fixed_ru[3];
+    double fixed_pos[3] = {known_pos_lat * D2R, known_pos_lon * D2R, known_pos_alt};
+    pos2ecef(fixed_pos, fixed_ru);
     prcopt_t rtklib_configuration_options = {
         positioning_mode,                                                                  /* positioning mode (PMODE_XXX) see src/algorithms/libs/rtklib/rtklib.h */
         0,                                                                                 /* solution type (0:forward,1:backward,2:combined) */
@@ -843,7 +854,7 @@ Rtklib_Pvt::Rtklib_Pvt(const ConfigurationInterface* configuration,
         threshold_reject_innovation,                                                       /* reject threshold of innovation (m) */
         threshold_reject_gdop,                                                             /* reject threshold of gdop */
         {},                                                                                /* double baseline[2] baseline length constraint {const,sigma} (m) */
-        {},                                                                                /* double ru[3]  rover position for fixed mode {x,y,z} (ecef) (m) */
+        {fixed_ru[0], fixed_ru[1], fixed_ru[2]},                                           /* double ru[3]  rover position for fixed mode {x,y,z} (ecef) (m) */
         {},                                                                                /* double rb[3]  base position for relative mode {x,y,z} (ecef) (m) */
         {"", ""},                                                                          /* char anttype[2][MAXANT]  antenna types {rover,base}  */
         {{}, {}},                                                                          /* double antdel[2][3]   antenna delta {{rov_e,rov_n,rov_u},{ref_e,ref_n,ref_u}} */

--- a/src/algorithms/PVT/gnuradio_blocks/rtklib_pvt_gs.cc
+++ b/src/algorithms/PVT/gnuradio_blocks/rtklib_pvt_gs.cc
@@ -538,6 +538,7 @@ rtklib_pvt_gs::rtklib_pvt_gs(uint32_t nchannels,
             d_local_time_str = std::string(" ") + time_zone_abrv + " (UTC " + utc_diff_str.substr(0, 3) + ":" + utc_diff_str.substr(3, 2) + ")";
         }
 
+    d_rtk_mode = rtk.opt.mode;
     if (d_enable_rx_clock_correction == true)
         {
             // setup two PVT solvers: internal solver for rx clock and user solver
@@ -2772,7 +2773,7 @@ int rtklib_pvt_gs::work(int noutput_items, gr_vector_const_void_star& input_item
                                             }
                                             write_rx_clock_bias(Rx_clock_offset_s, tag_tow_s_at_ch0, this->d_gnss_observables_map.begin()->second.PRN);
                                         }
-                                    if (d_hybrid_mode && (d_ps_channel != -1) && flag_ps_observed && (d_user_pvt_solver->get_sol_stat() == SOLQ_PPP))
+                                    if (d_hybrid_mode && (d_ps_channel != -1) && flag_ps_observed && (d_rtk_mode != PMODE_PPP_STATIC || (d_rtk_mode == PMODE_PPP_STATIC && d_user_pvt_solver->get_sol_stat() == SOLQ_PPP)))
                                         {
                                             // TODO: set output rate
                                             double clock_diff_s = -dt_gnssr_aowr_s_by_cp + Rx_clock_offset_s;

--- a/src/algorithms/PVT/gnuradio_blocks/rtklib_pvt_gs.h
+++ b/src/algorithms/PVT/gnuradio_blocks/rtklib_pvt_gs.h
@@ -263,6 +263,7 @@ private:
     uint32_t d_observable_interval_ms;
     uint32_t d_pvt_errors_counter;
     uint32_t d_output_cnt_for_clk_prop_after_fix;
+    uint16_t d_rtk_mode;
 
     bool d_dump;
     bool d_dump_mat;

--- a/src/algorithms/PVT/libs/pvt_ekf.cc
+++ b/src/algorithms/PVT/libs/pvt_ekf.cc
@@ -683,7 +683,7 @@ uint8_t Pvt_Ekf::get_observation(rtk_t* rtk, const obsd_t* obs, int n, const nav
     H_D = mat(4, n);
 
     // NOTE: resdop assumes the states are in ECEF
-    nv = resdop(obs, n, rs, dts, nav, x_p, x_v, azel, vsat.data(), v_D, H_D);
+    nv = resdop(obs, n, rs, dts, nav, &opt, x_p, x_v, azel, vsat.data(), v_D, H_D);
     const double measures_vel_var_ms2 = pow(d_measures_vel_sd_ms, 2);
     for (i = 0; i < nv; i++)
         {

--- a/src/algorithms/PVT/libs/rtklib_solver.cc
+++ b/src/algorithms/PVT/libs/rtklib_solver.cc
@@ -908,6 +908,7 @@ void Rtklib_Solver::get_current_has_obs_correction(const std::string &signal, ui
 }
 
 
+// FIXME: flag_clock_prop can be eliminated.
 bool Rtklib_Solver::get_PVT(const std::map<int, Gnss_Synchro> &gnss_observables_map, double kf_update_interval_s, bool flag_clock_prop)
 {
     std::map<int, Gnss_Synchro>::const_iterator gnss_observables_iter;
@@ -1670,7 +1671,7 @@ bool Rtklib_Solver::get_PVT(const std::map<int, Gnss_Synchro> &gnss_observables_
                             this->set_course_over_ground(new_cog);
                         }
 
-                    if (!flag_clock_prop)
+                    if (!d_rtk.opt.clock_bias_fixed)
                         {
                             this->set_time_offset_s(rx_position_and_time[3]);
                         }

--- a/src/algorithms/libs/rtklib/rtklib.h
+++ b/src/algorithms/libs/rtklib/rtklib.h
@@ -1005,7 +1005,9 @@ typedef struct
     int freqopt;                  /* disable L2-AR */
     char pppopt[256];             /* ppp option */
     bool bancroft_init;           /* enable Bancroft initialization for the first iteration of the PVT computation */
-    bool clock_bias_fixed;             /* receiver clock bias fixed mode*/
+    bool clock_bias_fixed;        /* receiver clock bias fixed mode */
+    bool fixed_position_mode;     /* Use fixed position and estimate only receiver clock bias */
+    double known_receiver_pos[3]; /* Known receiver geodetic position (lat, lon, alt) for fixed_position_mode */
 } prcopt_t;
 
 

--- a/src/algorithms/libs/rtklib/rtklib.h
+++ b/src/algorithms/libs/rtklib/rtklib.h
@@ -337,6 +337,7 @@ using fatalfunc_t = void(const char *);  //!<  fatal callback function type
 #define STR_HTTP 9     /* stream type: http */
 
 #define NP_PPP(opt) ((opt)->dynamics ? 9 : 3)                                                                    /* number of pos solution */
+// #define NP_PPP(opt) ((opt)->dynamics ? 9 : (opt)->fixed_position_mode ? 0 : 3)                                   /* number of pos solution */
 #define IC_PPP(s, opt) (NP_PPP(opt) + (s))                                                                       /* state index of clocks (s=0:gps,1:glo) */
 #define IT_PPP(opt) (IC_PPP(0, opt) + NSYS)                                                                      /* state index of tropos */
 #define NR_PPP(opt) (IT_PPP(opt) + ((opt)->tropopt < TROPOPT_EST ? 0 : ((opt)->tropopt == TROPOPT_EST ? 1 : 3))) /* number of solutions */

--- a/src/algorithms/libs/rtklib/rtklib_pntpos.cc
+++ b/src/algorithms/libs/rtklib/rtklib_pntpos.cc
@@ -431,6 +431,8 @@ int rescode(int iter, const obsd_t *obs, int n, const double *rs,
     int nx = NX;
     if (opt->clock_bias_fixed)
         nx = 3; // only position
+    else if (opt->fixed_position_mode)
+        nx = 1; // only clock offset
 
     trace(3, "resprng : n=%d\n", n);
 
@@ -512,7 +514,10 @@ int rescode(int iter, const obsd_t *obs, int n, const double *rs,
             /* design matrix */
             for (j = 0; j < nx; j++)
                 {
-                    H[j + nv * nx] = j < 3 ? -e[j] : (j == 3 ? 1.0 : 0.0);
+                    if (opt->fixed_position_mode)
+                        H[j + nv * nx] = 1.0;
+                    else
+                        H[j + nv * nx] = j < 3 ? -e[j] : (j == 3 ? 1.0 : 0.0);
                 }
 
             /* time system and receiver bias offset correction */
@@ -711,6 +716,10 @@ int estpos(const obsd_t *obs, int n, const double *rs, const double *dts,
                     x[6] = sol->dtr[3];
                 }
         }
+    else if (opt->fixed_position_mode)
+        {
+            nx = 1;  // clock bias and drift
+        }
 
     double *dx = new double[nx];
     double *Q = new double[nx * nx];
@@ -739,7 +748,7 @@ int estpos(const obsd_t *obs, int n, const double *rs, const double *dts,
         }
 
     // Rough first estimation to initialize the algorithm
-    if (opt->bancroft_init && (std::sqrt(x[0] * x[0] + x[1] * x[1] + x[2] * x[2]) < 0.1))
+    if (opt->bancroft_init && (std::sqrt(x[0] * x[0] + x[1] * x[1] + x[2] * x[2]) < 0.1) && !opt->fixed_position_mode)
         {
             arma::mat B = arma::mat(n, 4, arma::fill::zeros);
             for (i = 0; i < n; i++)
@@ -794,7 +803,10 @@ int estpos(const obsd_t *obs, int n, const double *rs, const double *dts,
                 }
             for (j = 0; j < nx; j++)
                 {
-                    x[j] += dx[j];
+                    if (opt->fixed_position_mode)
+                        x[3 + j] += dx[j];
+                    else
+                        x[j] += dx[j];
                 }
 
             if (norm_rtk(dx, nx) < 1e-4)
@@ -817,13 +829,21 @@ int estpos(const obsd_t *obs, int n, const double *rs, const double *dts,
                         {
                             sol->rr[j] = j < 3 ? x[j] : 0.0;
                         }
-                    for (j = 0; j < 3; j++)
+                    if (opt->fixed_position_mode)
                         {
-                            sol->qr[j] = static_cast<float>(Q[j + j * nx]);
+                            for (j = 0; j < 6; j++)
+                                sol->qr[j] = 0.0;
                         }
-                    sol->qr[3] = static_cast<float>(Q[1]);      /* cov xy */
-                    sol->qr[4] = static_cast<float>(Q[2 + nx]); /* cov yz */
-                    sol->qr[5] = static_cast<float>(Q[2]);      /* cov zx */
+                    else
+                        {
+                            for (j = 0; j < 3; j++)
+                                {
+                                    sol->qr[j] = static_cast<float>(Q[j + j * nx]);
+                                }
+                            sol->qr[3] = static_cast<float>(Q[1]);      /* cov xy */
+                            sol->qr[4] = static_cast<float>(Q[2 + nx]); /* cov yz */
+                            sol->qr[5] = static_cast<float>(Q[2]);      /* cov zx */
+                        }
                     sol->ns = static_cast<unsigned char>(ns);
                     sol->age = sol->ratio = 0.0;
 
@@ -984,7 +1004,7 @@ int raim_fde(const obsd_t *obs, int n, const double *rs,
 
 /* doppler residuals ---------------------------------------------------------*/
 int resdop(const obsd_t *obs, int n, const double *rs, const double *dts,
-    const nav_t *nav, const double *rr, const double *x,
+    const nav_t *nav, const prcopt_t *opt, const double *rr, const double *x,
     const double *azel, const int *vsat, double *v, double *H)
 {
     double lam;
@@ -998,6 +1018,10 @@ int resdop(const obsd_t *obs, int n, const double *rs, const double *dts,
     int j;
     int nv = 0;
     int band = 0;
+    int nx = 4;
+    if (opt->fixed_position_mode)
+        nx = 1; // only clock offset
+
 
     trace(3, "resdop  : n=%d\n", n);
 
@@ -1044,9 +1068,12 @@ int resdop(const obsd_t *obs, int n, const double *rs, const double *dts,
             v[nv] = -lam * obs[i].D[band] - (rate + x[3] - SPEED_OF_LIGHT_M_S * dts[1 + i * 2]);
 
             /* design matrix */
-            for (j = 0; j < 4; j++)
+            for (j = 0; j < nx; j++)
                 {
-                    H[j + nv * 4] = j < 3 ? -e[j] : 1.0;
+                    if (opt->fixed_position_mode)
+                        H[j + nv * nx] = 1.0;
+                    else
+                        H[j + nv * nx] = j < 3 ? -e[j] : 1.0;
                 }
 
             nv++;
@@ -1061,8 +1088,13 @@ void estvel(const obsd_t *obs, int n, const double *rs, const double *dts,
     const double *azel, const int *vsat)
 {
     double x[4] = {0};
-    double dx[4];
-    double Q[16];
+    int nx = 4;
+    if (opt->fixed_position_mode)
+        {
+            nx = 1; // only clock drift
+        }
+    double *dx = new double[nx];
+    double *Q = new double[nx * nx];
     double *v;
     double *H;
     int i;
@@ -1072,27 +1104,30 @@ void estvel(const obsd_t *obs, int n, const double *rs, const double *dts,
     trace(3, "estvel  : n=%d\n", n);
 
     v = mat(n, 1);
-    H = mat(4, n);
+    H = mat(nx, n);
 
     for (i = 0; i < MAXITR; i++)
         {
             /* doppler residuals */
-            if ((nv = resdop(obs, n, rs, dts, nav, sol->rr, x, azel, vsat, v, H)) < 4)
+            if ((nv = resdop(obs, n, rs, dts, nav, opt, sol->rr, x, azel, vsat, v, H)) < 4)
                 {
                     break;
                 }
             /* least square estimation */
-            if (lsq(H, v, 4, nv, dx, Q))
+            if (lsq(H, v, nx, nv, dx, Q))
                 {
                     break;
                 }
 
-            for (j = 0; j < 4; j++)
+            for (j = 0; j < nx; j++)
                 {
-                    x[j] += dx[j];
+                    if (opt->fixed_position_mode)
+                        x[3 + j] += dx[j];
+                    else
+                        x[j] += dx[j];
                 }
 
-            if (norm_rtk(dx, 4) < 1e-6)
+            if (norm_rtk(dx, nx) < 1e-6)
                 {
                     for (i = 0; i < 3; i++)
                         {

--- a/src/algorithms/libs/rtklib/rtklib_pntpos.h
+++ b/src/algorithms/libs/rtklib/rtklib_pntpos.h
@@ -113,7 +113,7 @@ int raim_fde(const obsd_t *obs, int n, const double *rs,
 
 /* doppler residuals ---------------------------------------------------------*/
 int resdop(const obsd_t *obs, int n, const double *rs, const double *dts,
-    const nav_t *nav, const double *rr, const double *x,
+    const nav_t *nav, const prcopt_t *opt, const double *rr, const double *x,
     const double *azel, const int *vsat, double *v, double *H);
 
 /* estimate receiver velocity ------------------------------------------------*/

--- a/src/algorithms/libs/rtklib/rtklib_ppp.cc
+++ b/src/algorithms/libs/rtklib/rtklib_ppp.cc
@@ -1727,34 +1727,34 @@ int res_ppp(int iter __attribute__((unused)), const obsd_t *obs, int n, const do
                     if (opt->maxinno > 0.0 && fabs(v[nv]) > opt->maxinno && sys != SYS_GLO)
                         {
 #endif
-                    trace(2, "ppp outlier rejected %s sat=%2d type=%d v=%.3f\n",
-                        time_str(obs[i].time, 0), sat, j, v[nv]);
-                    rtk->ssat[sat - 1].rejc[0]++;
-                    continue;
+                            trace(2, "ppp outlier rejected %s sat=%2d type=%d v=%.3f\n",
+                                time_str(obs[i].time, 0), sat, j, v[nv]);
+                            rtk->ssat[sat - 1].rejc[0]++;
+                            continue;
+                        }
+                    if (j == 0)
+                        {
+                            rtk->ssat[sat - 1].vsat[0] = 1;
+                        }
+                    nv++;
+                        }
                 }
-            if (j == 0)
+    for (i = 0; i < nv; i++)
+        {
+            for (j = 0; j < nv; j++)
                 {
-                    rtk->ssat[sat - 1].vsat[0] = 1;
+                    R[i + j * nv] = i == j ? var[i] : 0.0;
                 }
-            nv++;
         }
-}
-for (i = 0; i < nv; i++)
-    {
-        for (j = 0; j < nv; j++)
-            {
-                R[i + j * nv] = i == j ? var[i] : 0.0;
-            }
-    }
-trace(5, "x=\n");
-tracemat(5, x, 1, nx, 8, 3);
-trace(5, "v=\n");
-tracemat(5, v, 1, nv, 8, 3);
-trace(5, "H=\n");
-tracemat(5, H, nx, nv, 8, 3);
-trace(5, "R=\n");
-tracemat(5, R, nv, nv, 8, 5);
-return nv;
+    trace(5, "x=\n");
+    tracemat(5, x, 1, nx, 8, 3);
+    trace(5, "v=\n");
+    tracemat(5, v, 1, nv, 8, 3);
+    trace(5, "H=\n");
+    tracemat(5, H, nx, nv, 8, 3);
+    trace(5, "R=\n");
+    tracemat(5, R, nv, nv, 8, 5);
+    return nv;
 }
 
 

--- a/src/algorithms/libs/rtklib/rtklib_ppp.cc
+++ b/src/algorithms/libs/rtklib/rtklib_ppp.cc
@@ -1203,6 +1203,7 @@ void udpos_ppp(rtk_t *rtk)
         {
             for (i = 0; i < 3; i++)
                 {
+                    // NOTE: small variance ensure that estimation works only for other variables.
                     initx(rtk, rtk->opt.ru[i], 1E-8, i);
                 }
             return;
@@ -1681,6 +1682,14 @@ int res_ppp(int iter __attribute__((unused)), const obsd_t *obs, int n, const do
 
                     v[nv] = meas[j] - r;
 
+                    // // Skip for fixed mode
+                    // if (!opt->fixed_position_mode)
+                    //     {
+                    //         for (k = 0; k < 3; k++)
+                    //             {
+                    //                 H[k + nx * nv] = -e[k];
+                    //             }
+                    //     }
                     for (k = 0; k < 3; k++)
                         {
                             H[k + nx * nv] = -e[k];

--- a/src/algorithms/libs/rtklib/rtklib_rtkpos.cc
+++ b/src/algorithms/libs/rtklib/rtklib_rtkpos.cc
@@ -2811,7 +2811,6 @@ int rtkpos(rtk_t *rtk, const obsd_t *obs, int n, const nav_t *nav)
 
     time = rtk->sol.time; /* previous epoch */
 
-    // TODO: add only clock bias estimation in pntpos
     /* rover position by single point positioning */
     if (!pntpos(obs, nu, nav, &rtk->opt, &rtk->sol, nullptr, rtk->ssat, msg))
         {
@@ -2842,7 +2841,6 @@ int rtkpos(rtk_t *rtk, const obsd_t *obs, int n, const nav_t *nav)
     /* precise point positioning */
     if (opt->mode >= PMODE_PPP_KINEMA)
         {
-            // TODO: add only clock bias estimation in pppos
             pppos(rtk, obs, nu, nav);
             outsolstat(rtk);
             return 1;

--- a/src/algorithms/libs/rtklib/rtklib_rtkpos.cc
+++ b/src/algorithms/libs/rtklib/rtklib_rtkpos.cc
@@ -2658,6 +2658,20 @@ void rtkinit(rtk_t *rtk, const prcopt_t *opt)
     trace(3, "rtkinit :\n");
 
     rtk->sol = sol0;
+    if (opt->fixed_position_mode)
+        {
+            double known_pos_geodetic[3] = {
+                opt->known_receiver_pos[0] * D2R,
+                opt->known_receiver_pos[1] * D2R,
+                opt->known_receiver_pos[2]};
+            double known_pos_ecef[3];
+            pos2ecef(known_pos_geodetic, known_pos_ecef);
+            for (i = 0; i < 3; i++)
+                {
+                    rtk->sol.rr[i] = known_pos_ecef[i];
+                    rtk->sol.rr[3 + i] = 0.0;  // velocity
+                }
+        }
     for (i = 0; i < 6; i++)
         {
             rtk->rb[i] = 0.0;
@@ -2797,6 +2811,7 @@ int rtkpos(rtk_t *rtk, const obsd_t *obs, int n, const nav_t *nav)
 
     time = rtk->sol.time; /* previous epoch */
 
+    // TODO: add only clock bias estimation in pntpos
     /* rover position by single point positioning */
     if (!pntpos(obs, nu, nav, &rtk->opt, &rtk->sol, nullptr, rtk->ssat, msg))
         {
@@ -2827,6 +2842,7 @@ int rtkpos(rtk_t *rtk, const obsd_t *obs, int n, const nav_t *nav)
     /* precise point positioning */
     if (opt->mode >= PMODE_PPP_KINEMA)
         {
+            // TODO: add only clock bias estimation in pppos
             pppos(rtk, obs, nu, nav);
             outsolstat(rtk);
             return 1;

--- a/src/algorithms/libs/rtklib/rtklib_rtksvr.h
+++ b/src/algorithms/libs/rtklib/rtklib_rtksvr.h
@@ -65,7 +65,7 @@ const prcopt_t PRCOPT_DEFAULT = {            /* defaults processing options */
     {}, {}, {},                              /* baseline, ru, rb */
     {"", ""},                                /* anttype */
     {}, {}, {},                              /* antdel, pcv, exsats */
-    0, 0, 0, {"", ""}, {}, 0, {{}, {}}, {{}, {{}, {}}, {{}, {}}, {}, {}}, 0, {}, true, false};
+    0, 0, 0, {"", ""}, {}, 0, {{}, {}}, {{}, {{}, {}}, {{}, {}}, {}, {}}, 0, {}, true, false, false, {}};
 
 
 void writesolhead(stream_t *stream, const solopt_t *solopt);

--- a/src/tests/unit-tests/signal-processing-blocks/pvt/nmea_printer_test.cc
+++ b/src/tests/unit-tests/signal-processing-blocks/pvt/nmea_printer_test.cc
@@ -135,8 +135,10 @@ void NmeaPrinterTest::conf()
         {{}, {{}, {}}, {{}, {}}, {}, {}},                                                  /*  exterr_t exterr   extended receiver error model */
         0,                                                                                 /* disable L2-AR */
         {},                                                                                /* char pppopt[256]   ppp option   "-GAP_RESION="  default gap to reset iono parameters (ep) */
-        true,
-        false                                                                               /* enable Bancroft initialization for the first iteration of the PVT computation, useful in some geometries */
+        true,                                                                              /* enable Bancroft initialization for the first iteration of the PVT computation, useful in some geometries */
+        false,                                                                             /* receiver clock bias fixed mode */
+        false,                                                                             /* Use fixed position and estimate only receiver clock bias */
+        {}                                                                                 /* Known receiver geodetic position (lat, lon, alt) for fixed_position_mode */
     };
 
     rtkinit(&rtk, &rtklib_configuration_options);

--- a/src/tests/unit-tests/signal-processing-blocks/pvt/rinex_printer_test.cc
+++ b/src/tests/unit-tests/signal-processing-blocks/pvt/rinex_printer_test.cc
@@ -135,8 +135,10 @@ void RinexPrinterTest::conf()
         {{}, {{}, {}}, {{}, {}}, {}, {}},                                                  /*  exterr_t exterr   extended receiver error model */
         0,                                                                                 /* disable L2-AR */
         {},                                                                                /* char pppopt[256]   ppp option   "-GAP_RESION="  default gap to reset iono parameters (ep) */
-        true,
-        false                                                                               /* enable Bancroft initialization for the first iteration of the PVT computation, useful in some geometries */
+        true,                                                                              /* enable Bancroft initialization for the first iteration of the PVT computation, useful in some geometries */
+        false,                                                                             /* receiver clock bias fixed mode */
+        false,                                                                             /* Use fixed position and estimate only receiver clock bias */
+        {}                                                                                 /* Known receiver geodetic position (lat, lon, alt) for fixed_position_mode */
     };
 
     rtkinit(&rtk, &rtklib_configuration_options);


### PR DESCRIPTION
## Describe your changes
- Add the GS position fixed mode to estimate only clock bias of the receiver for hybrid method.
- Implemented and  verified with both Single (code-correlation) and PPP_Fixed (carrier phase-correlation).

## Validation result
- Verification note is [here](https://scrapbox.io/my-research/Improve_clock_offset_of_GS's_GNSS_receiver_for_hybrid).
- [Log file link](https://anu365-my.sharepoint.com/my?id=%2Fpersonal%2Fu7586757%5Fanu%5Fedu%5Fau%2FDocuments%2FANU%2FLab%2FAsynchronousRanging%2FExperiment%2F20250723%5Fgs%5Fposition%5Ffixed%5Fmode&login_hint=u7586757%40anu%2Eedu%2Eau&source=waffle)